### PR TITLE
Add isomorphic support

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,3 @@
 {
-  "presets": ["@babel/preset-env"]
+  "presets": [["@babel/preset-env", { "useBuiltIns": "usage" }]]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.1.4] - 2019-03-1
+## [0.2.0] - 2019-03-27
+
+### Added
+
+- Client is now isomorphic an can run on browser and server without configuration changes
+
+### Changed
+
+- Babel polyfill only imports what is required with the `useBuiltIns` settings
+
+## [0.1.4] - 2019-03-01
 
 ### Added
 

--- a/dist/api/index.js
+++ b/dist/api/index.js
@@ -1,9 +1,13 @@
 "use strict";
 
+require("core-js/modules/es6.object.define-property");
+
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
 exports.default = _default;
+
+require("core-js/modules/es6.object.assign");
 
 var _oauth2Clients = _interopRequireDefault(require("./oauth2-clients"));
 

--- a/dist/api/me.js
+++ b/dist/api/me.js
@@ -1,5 +1,7 @@
 "use strict";
 
+require("core-js/modules/es6.object.define-property");
+
 Object.defineProperty(exports, "__esModule", {
   value: true
 });

--- a/dist/api/oauth2-clients.js
+++ b/dist/api/oauth2-clients.js
@@ -1,5 +1,7 @@
 "use strict";
 
+require("core-js/modules/es6.object.define-property");
+
 Object.defineProperty(exports, "__esModule", {
   value: true
 });

--- a/dist/api/playlists.js
+++ b/dist/api/playlists.js
@@ -1,5 +1,7 @@
 "use strict";
 
+require("core-js/modules/es6.object.define-property");
+
 Object.defineProperty(exports, "__esModule", {
   value: true
 });

--- a/dist/api/stations.js
+++ b/dist/api/stations.js
@@ -1,15 +1,29 @@
 "use strict";
 
+require("core-js/modules/es6.object.define-property");
+
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
 exports.default = _default;
 
-var _phoenix = require("phoenix");
+require("core-js/modules/es6.function.bind");
+
+require("core-js/modules/es6.promise");
+
+require("core-js/modules/es6.regexp.replace");
 
 var _wrap = _interopRequireDefault(require("../utils/wrap"));
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+var Socket;
+
+if (typeof window === 'undefined') {
+  Socket = require('phoenix-channels');
+} else {
+  Socket = require('phoenix');
+}
 
 function _default(api) {
   return {
@@ -49,13 +63,13 @@ function _default(api) {
       var socket;
 
       if (headers.Authorization) {
-        socket = new _phoenix.Socket(baseURL.replace('http', 'ws') + '/socket', {
+        socket = new Socket(baseURL.replace('http', 'ws') + '/socket', {
           params: {
             token: headers.Authorization.substring('Bearer '.length)
           }
         });
       } else {
-        socket = new _phoenix.Socket(baseURL.replace('http', 'ws') + '/socket');
+        socket = new Socket(baseURL.replace('http', 'ws') + '/socket');
       }
 
       socket.connect();

--- a/dist/api/users.js
+++ b/dist/api/users.js
@@ -1,5 +1,7 @@
 "use strict";
 
+require("core-js/modules/es6.object.define-property");
+
 Object.defineProperty(exports, "__esModule", {
   value: true
 });

--- a/dist/index.js
+++ b/dist/index.js
@@ -1,11 +1,11 @@
 "use strict";
 
+require("core-js/modules/es6.object.define-property");
+
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
 exports.default = void 0;
-
-require("@babel/polyfill");
 
 var _axios = _interopRequireDefault(require("axios"));
 

--- a/dist/middleware/refresh-retry.js
+++ b/dist/middleware/refresh-retry.js
@@ -1,9 +1,15 @@
 "use strict";
 
+require("core-js/modules/es6.object.define-property");
+
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
 exports.default = _default;
+
+require("core-js/modules/es6.promise");
+
+require("regenerator-runtime/runtime");
 
 function asyncGeneratorStep(gen, resolve, reject, _next, _throw, key, arg) { try { var info = gen[key](arg); var value = info.value; } catch (error) { reject(error); return; } if (info.done) { resolve(value); } else { Promise.resolve(value).then(_next, _throw); } }
 

--- a/dist/utils/wrap.js
+++ b/dist/utils/wrap.js
@@ -1,9 +1,15 @@
 "use strict";
 
+require("core-js/modules/es6.object.define-property");
+
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
 exports.default = void 0;
+
+require("core-js/modules/es6.promise");
+
+require("regenerator-runtime/runtime");
 
 function asyncGeneratorStep(gen, resolve, reject, _next, _throw, key, arg) { try { var info = gen[key](arg); var value = info.value; } catch (error) { reject(error); return; } if (info.done) { resolve(value); } else { Promise.resolve(value).then(_next, _throw); } }
 

--- a/lib/api/stations.js
+++ b/lib/api/stations.js
@@ -1,5 +1,10 @@
-import { Socket } from 'phoenix';
 import wrap from '../utils/wrap';
+let Socket;
+if (typeof window === 'undefined') {
+  Socket = require('phoenix-channels');
+} else {
+  Socket = require('phoenix');
+}
 
 export default function(api) {
   return {

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,4 +1,3 @@
-import '@babel/polyfill';
 import axios from 'axios';
 import refreshRetry from './middleware/refresh-retry';
 import endpoints from './api';

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "dependencies": {
     "@babel/polyfill": "^7.0.0",
     "axios": "^0.18.0",
-    "phoenix": "^1.4.0"
+    "phoenix": "^1.4.0",
+    "phoenix-channels": "^1.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ripple.fm",
-  "version": "0.1.4",
+  "version": "0.2.0",
   "description": "Javascript client library for ripple.fm API",
   "main": "dist/index.js",
   "repository": "https://github.com/ripplefm/ripple.fm-js",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1137,6 +1137,10 @@ is-plain-object@^2.0.1, is-plain-object@^2.0.3, is-plain-object@^2.0.4:
   dependencies:
     isobject "^3.0.1"
 
+is-typedarray@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-typedarray/-/is-typedarray-1.0.0.tgz#e479c80858df0c1b11ddda6940f96011fcda4a9a"
+
 is-windows@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-1.0.2.tgz#d1850eb9791ecd18e6182ce12a30f396634bb19d"
@@ -1286,6 +1290,10 @@ ms@2.0.0:
 ms@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.1.tgz#30a5864eb3ebb0a66f2ebe6d727af06a09d86e0a"
+
+nan@^2.11.0:
+  version "2.13.2"
+  resolved "https://registry.yarnpkg.com/nan/-/nan-2.13.2.tgz#f51dc7ae66ba7d5d55e1e6d4d8092e802c9aefe7"
 
 nan@^2.9.2:
   version "2.11.1"
@@ -1441,6 +1449,12 @@ path-is-absolute@^1.0.0:
 path-parse@^1.0.5:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.6.tgz#d62dbb5679405d72c4737ec58600e9ddcf06d24c"
+
+phoenix-channels@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/phoenix-channels/-/phoenix-channels-1.0.0.tgz#4de3a7a3427483deffc4908d8fecac725db06d6a"
+  dependencies:
+    websocket "^1.0.24"
 
 phoenix@^1.4.0:
   version "1.4.0"
@@ -1766,6 +1780,12 @@ trim-right@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/trim-right/-/trim-right-1.0.1.tgz#cb2e1203067e0c8de1f614094b9fe45704ea6003"
 
+typedarray-to-buffer@^3.1.5:
+  version "3.1.5"
+  resolved "https://registry.yarnpkg.com/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz#a97ee7a9ff42691b9f783ff1bc5112fe3fca9080"
+  dependencies:
+    is-typedarray "^1.0.0"
+
 unicode-canonical-property-names-ecmascript@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-1.0.4.tgz#2619800c4c825800efdd8343af7dd9933cbe2818"
@@ -1817,6 +1837,15 @@ util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
 
+websocket@^1.0.24:
+  version "1.0.28"
+  resolved "https://registry.yarnpkg.com/websocket/-/websocket-1.0.28.tgz#9e5f6fdc8a3fe01d4422647ef93abdd8d45a78d3"
+  dependencies:
+    debug "^2.2.0"
+    nan "^2.11.0"
+    typedarray-to-buffer "^3.1.5"
+    yaeti "^0.0.6"
+
 wide-align@^1.1.0:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/wide-align/-/wide-align-1.1.3.tgz#ae074e6bdc0c14a431e804e624549c633b000457"
@@ -1826,6 +1855,10 @@ wide-align@^1.1.0:
 wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
+
+yaeti@^0.0.6:
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/yaeti/-/yaeti-0.0.6.tgz#f26f484d72684cf42bedfb76970aa1608fbf9577"
 
 yallist@^3.0.0, yallist@^3.0.2:
   version "3.0.2"


### PR DESCRIPTION
### Added

- Client is now isomorphic an can run on browser and server without configuration changes

### Changed

- Babel polyfill only imports what is required with the `useBuiltIns` settings