### PR TITLE
Fix errors causing crashes for refresh retry middleware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.5] - 2019-03-27
+
+### Fixed
+
+- Errors that cannot be fixed by refresh-retry middleware are actually thrown instead of crashing now
+
 ## [0.2.4] - 2019-03-27
 
 ### Changed

--- a/dist/middleware/refresh-retry.js
+++ b/dist/middleware/refresh-retry.js
@@ -28,6 +28,8 @@ function _default(onExpire, api) {
         }).catch(function (_) {
           return reject(err);
         });
+      } else {
+        reject(err);
       }
     });
   };

--- a/lib/middleware/refresh-retry.js
+++ b/lib/middleware/refresh-retry.js
@@ -15,6 +15,8 @@ export default function(onExpire, api) {
           })
           .then(res => resolve(res))
           .catch(_ => reject(err));
+      } else {
+        reject(err);
       }
     });
   };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ripple.fm",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "Javascript client library for ripple.fm API",
   "main": "dist/index.js",
   "repository": "https://github.com/ripplefm/ripple.fm-js",


### PR DESCRIPTION
### Fixed

- Errors that cannot be fixed by refresh-retry middleware are actually thrown instead of crashing now