### PR TITLE
Add function to remove event listeners for channels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.6] - 2019-03-29
+
+### Changed
+
+- Added `off` function for channel object returned after joining a station. Allows to remove event listeners bound to `on` function
+
+### Fixed
+
+- Fixed import for phoenix channels socket
+
 ## [0.2.5] - 2019-03-27
 
 ### Fixed

--- a/dist/api/stations.js
+++ b/dist/api/stations.js
@@ -20,9 +20,9 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 var Socket;
 
 if (typeof window === 'undefined') {
-  Socket = require('phoenix-channels');
+  Socket = require('phoenix-channels').Socket;
 } else {
-  Socket = require('phoenix');
+  Socket = require('phoenix').Socket;
 }
 
 function _default(api) {
@@ -79,9 +79,8 @@ function _default(api) {
           return resolve({
             on: channel.on.bind(channel),
             push: channel.push.bind(channel),
-            leave: function leave() {
-              return channel.leave;
-            },
+            off: channel.off.bind(channel),
+            leave: channel.leave.bind(channel),
             channel: channel,
             socket: socket
           });

--- a/lib/api/stations.js
+++ b/lib/api/stations.js
@@ -1,9 +1,9 @@
 import wrap from '../utils/wrap';
 let Socket;
 if (typeof window === 'undefined') {
-  Socket = require('phoenix-channels');
+  Socket = require('phoenix-channels').Socket;
 } else {
-  Socket = require('phoenix');
+  Socket = require('phoenix').Socket;
 }
 
 export default function(api) {
@@ -34,7 +34,8 @@ export default function(api) {
             resolve({
               on: channel.on.bind(channel),
               push: channel.push.bind(channel),
-              leave: () => channel.leave,
+              off: channel.off.bind(channel),
+              leave: channel.leave.bind(channel),
               channel,
               socket
             })

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ripple.fm",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "Javascript client library for ripple.fm API",
   "main": "dist/index.js",
   "repository": "https://github.com/ripplefm/ripple.fm-js",


### PR DESCRIPTION
### Changed

- Added `off` function for channel object returned after joining a station. Allows to remove event listeners bound to `on` function

### Fixed

- Fixed import for phoenix channels socket